### PR TITLE
change default auth method for documentation on developer.bcc.no to bcc-login

### DIFF
--- a/.github/workflows/build-and-deploy-documentations.yml
+++ b/.github/workflows/build-and-deploy-documentations.yml
@@ -30,3 +30,4 @@ jobs:
           title: PDF Service
           description: ${{ github.event.repository.description }}
           branch: master
+          authentication: 'portal'


### PR DESCRIPTION
change default auth method for documentation on developer.bcc.no to bcc-login